### PR TITLE
Making the About heading modifiable

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -17,6 +17,7 @@ copyright = "Copyright (c) 2018, g1eny0ung; all rights reserved."
   motto = "Motto"
   # description = ""
   # avatar = ""
+  aboutHead="About"
   
   # email = ""
   # github = ""

--- a/layouts/partials/back.html
+++ b/layouts/partials/back.html
@@ -44,7 +44,7 @@
 
     <section class="ui stacked segments">
       <header class="ui inverted segment">
-        <h2 class="ui header">{{- i18n "aboutHeader" -}}</h2>
+        <h2 class="ui header">{{- .Site.Params.aboutHead -}}</h2>
       </header>
 
       <article class="ui inverted segment">


### PR DESCRIPTION
The about heading can be modified now using the `aboutHead` variable in `config.toml`.