### PR TITLE
Use relURL for JS and CSS

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,12 +1,12 @@
-<script src="/js/jquery.min.js"></script>
-<script src="/js/semantic.min.js"></script>
-<script src="/js/imagesloaded.pkgd.min.js"></script>
-<script src="/js/masonry.pkgd.min.js"></script>
-<script src="/js/nav.js"></script>
-<script src="/js/header.js"></script>
-<script src="/js/main.js"></script>
-<script src="/js/theme.js"></script>
-<script src="/js/html2canvas.min.js"></script>
+<script src="{{ "/js/jquery.min.js" | relURL }}"></script>
+<script src="{{ "/js/semantic.min.js" | relURL }}"></script>
+<script src="{{ "/js/imagesloaded.pkgd.min.js" | relURL }}"></script>
+<script src="{{ "/js/masonry.pkgd.min.js" | relURL }}"></script>
+<script src="{{ "/js/nav.js" | relURL }}"></script>
+<script src="{{ "/js/header.js" | relURL }}"></script>
+<script src="{{ "/js/main.js" | relURL }}"></script>
+<script src="{{ "/js/theme.js" | relURL }}"></script>
+<script src="{{ "/js/html2canvas.min.js" | relURL }}"></script>
 
 {{ if .Site.GoogleAnalytics }}
   {{ template "_internal/google_analytics_async.html" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -23,9 +23,9 @@
 <!-- Twitter Cards -->
 {{ template "_internal/twitter_cards.html" . }}
 
-<link rel="stylesheet" href="/css/github-markdown.css" />
-<link rel="stylesheet" href="/css/semantic.min.css" />
-<link rel="stylesheet" href="/css/site.css" />
+<link rel="stylesheet" href="{{ "/css/github-markdown.css" | relURL }}"/>
+<link rel="stylesheet" href="{{ "/css/semantic.min.css" | relURL }}" />
+<link rel="stylesheet" href="{{ "/css/site.css" | relURL }}" />
 
 {{ if .Site.Params.linkColor }}
 <style>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -2,7 +2,7 @@
   <section class="ui top attached center aligned segment">
     <div class="ui small circular image">
       {{ if isset .Site.Params "avatar" }}
-        <img src="{{ .Site.Params.avatar }}">
+        <img src="{{ .Site.Params.avatar | relURL }}">
       {{ end }}
     </div>
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -13,14 +13,14 @@
 
     <div class="ui horizontal list">
       {{ if gt (len (where .Site.RegularPages "Section" "==" "posts")) 0 }}
-      <a class="item" href="/posts">
+      <a class="item" href="{{ "/posts" | relURL }}">
         <i class="archive icon" title="{{ i18n "archives" }}"></i>
       </a>
       {{ end }}
-      <a class="item" href="/tags">
+      <a class="item" href="{{ "/tags" | relURL }}">
         <i class="tags icon" title="{{ i18n "allTags" }}"></i>
       </a>
-      <a class="item" href="/categories">
+      <a class="item" href="{{ "/categories" | relURL }}">
         <i class="th list icon" title="{{ i18n "allCategories" }}"></i>
       </a>
     </div>


### PR DESCRIPTION
This changes the URLs for included JS and CSS to use relURL, which respects the
baseurl parameter in config.toml.