### PR TITLE
Add doc of Open Graph/Twitter image param

### DIFF
--- a/docs/params-configurations.md
+++ b/docs/params-configurations.md
@@ -16,7 +16,7 @@
   # headerBottomText = ""
 
   rss = true
-
+  images = [""]
   utterancesRepo = "g1eny0ung/g1eny0ung.github.io"
 
   # valine = true


### PR DESCRIPTION
This image will be used when sharing your site in social media or messaging apps. Value can be a link. If it's a relative link it seems to work best if you point out the internal subfolder within your static files directory like ["img/yesnoyes.png"]. 
It is also required for the values to be inside [""] brackets and you need to add front matter values like "images" "video" in your arquetypes to populate the twitter and open graph meta tags. Values in front matter should also be like config file values within [""]. View HUGO documentation on Internal Templates for more info.