### PR TITLE
 Clickable Button to cards if there is Read more text.

### DIFF
--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -36,6 +36,10 @@
     </div>
     <div class="description">
       {{ .Summary | emojify | safeHTML }}
+      {{ if .Truncated }}
+      <!-- This <div> includes a read more link, but only if the summary is truncated... -->
+      <a class="ui small bottom right attached green label" href="{{ .RelPermalink }}">Read More...</a>
+      {{ end }}
     </div>
   </div>
 


### PR DESCRIPTION
If there's content after the  <!--more--> tag in the markdown a button will appear at the bottom right of the card in the summary view. Implemented this on my site because there was no indicator of when there is more text outside the description in the summary view. In my site i made the button green because i think it's a fun color for a button. But it's your theme. You should chose the color! Also, I have no clue if my syntax is correct, this worked but it probably needs correction. Greetings.