### PR TITLE
Fix "minuteRead" i18n for post summaries

### DIFF
--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -47,7 +47,7 @@
     </div>
     <div class="reading-time">
       <i class="clock icon"></i>
-      {{- .ReadingTime -}}{{- i18n "minuteRead" -}}
+      {{- .ReadingTime -}}{{- i18n "minuteRead" .ReadingTime -}}
     </div>
   </div>
 </article>


### PR DESCRIPTION
Thanks for the wonderful theme!

I noticed that post summary "minuteRead" i18n breaks when "en" language is selected.
Upon checking, I discovered that the i18n directive hadn't been passed the quantity variable. I added it, and a seemed to be good again. :)