### PR TITLE
Construct $termLink with relLangURL  to generate correct category and tag links

### DIFF
--- a/layouts/categories/terms.html
+++ b/layouts/categories/terms.html
@@ -23,7 +23,7 @@
     {{ range .Data.Terms.Alphabetical }}
     {{ $termLink := printf "/%s/%s/" $data.Plural .Term | urlize }}
     <h3 class="ui header">
-      <a href="{{ $termLink }}">{{ .Term | humanize | title }}</a>&nbsp;
+      <a href="{{ $termLink | relLangURL }}">{{ .Term | humanize | title }}</a>&nbsp;
       {{- T "article" .Count -}}
     </h3>
     <ul>

--- a/layouts/tags/terms.html
+++ b/layouts/tags/terms.html
@@ -23,7 +23,7 @@
     {{ range .Data.Terms.Alphabetical }}
     {{ $termLink := printf "/%s/%s/" $data.Plural .Term | urlize }}
     <h3 class="ui header">
-      <a href="{{ $termLink }}">{{ .Term | humanize | title }}</a>&nbsp;
+      <a href="{{ $termLink | relLangURL }}">{{ .Term | humanize | title }}</a>&nbsp;
       {{- T "article" .Count -}}
     </h3>
     <ul>


### PR DESCRIPTION
Example:
Site: example.com/sub-site/

When visiting: example.com/sub-site/categories/
* The category links are: example.com/categories/cat1/


It should now show as: example.com/sub-site/categories/cat1/
* And with an added benefit to use a different Lang for categories and tags.

