### PR TITLE
Consider motto as safeHTML

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -9,7 +9,7 @@
     <h1 class="ui medium header">
       {{- if .Site.Params.headerTitle -}}{{ .Site.Params.headerTitle }}{{ else }}{{ .Site.Params.author }}{{ T "blogAlias" }}{{- end -}}
       <div class="sub header">
-        {{- .Site.Params.motto -}}
+        {{- .Site.Params.motto | safeHTML -}}
       </div>
     </h1>
 


### PR DESCRIPTION
This allows for custom HTML to be added to the motto.
Useful to add a link for example.

Signed-off-by: Julien DOCHE <julien.doche@gmail.com>