### PR TITLE
Suggested fix reading time

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -70,7 +70,7 @@
                   {{ end }}
                 {{ end }}
 
-              | {{ .ReadingTime }}{{ i18n "minuteRead" }}
+              | {{ .ReadingTime }}{{ i18n "minuteRead" .ReadingTime }}
 
               {{ if ne .Params.nolastmod true }}
               | {{ i18n "updateAt" }}


### PR DESCRIPTION
Thanks for your work on this project! It's a wonderful theme.

In this PR, I propose updating the implementation of the reading time to be the same as the one [here](https://github.com/g1eny0ung/hugo-theme-dream/blob/bd3f67ab8c343412f90ac10853491d73980c51ad/layouts/_default/summary.html#L56).

Before this change, this is how the reading time is displayed:

![Screen Shot 2021-05-21 at 05 46 00](https://user-images.githubusercontent.com/3599813/119125669-129d5800-ba00-11eb-895c-438692461920.png)

After this change, this is how it is displayed:

![Screen Shot 2021-05-21 at 05 45 09](https://user-images.githubusercontent.com/3599813/119125483-d0741680-b9ff-11eb-9d0a-046a92da1d6b.png)
