### PR TITLE
Adding collapsible tags

### DIFF
--- a/docs/params-configurations.md
+++ b/docs/params-configurations.md
@@ -66,6 +66,8 @@
   # reversePostAndAside = true
   # shareInAside = true
   fixedNav = true
+  # collapsibleTags = true
+  # collapseBySummary = true
 
   [params.advanced]
     customCSS = ["css/custom.css"]
@@ -262,6 +264,14 @@ Display share buttons in aside, not under the post title.
 ### fixedNav = true
 
 Make navbar fixed when scrolling.
+
+### collapsibleTags = true
+
+Break tags into multiple levels by a collapsible manner.
+
+### collapseBySummary = false
+
+collapsibleTags collapses tags by .Title by default and by .Summary when collapseBySummary is true.
 
 ## Advanced
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -73,6 +73,8 @@ theme = "hugo-theme-dream"
   # reversePostAndAside = true
   # shareInAside = true
   # fixedNav = true
+  # collapsibleTags = true
+  # collapseBySummary = false
 
   # [params.advanced]
   #   customCSS = ["css/custom.css"]

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -28,6 +28,10 @@ other = "{{ .Count }} categories"
 one = "1 article"
 other = "{{ .Count }} articles"
 
+[group]
+one = "1 group"
+other = "{{ .Count }} groups"
+
 [socialLinks]
 other = "Social Links"
 

--- a/layouts/partials/collapsibleTags.html
+++ b/layouts/partials/collapsibleTags.html
@@ -1,0 +1,38 @@
+<details>
+  {{ $s := slice }}
+  {{ range .context.WeightedPages }}
+    {{ $s = $s | append .Title }}
+  {{ end }}
+  {{ $set := uniq $s }}
+  {{ $len := len $set }}
+  {{ $collapseBySummary := .collapseBySummary }}
+  <summary>
+    <h3 style="display: inline; color: #2E8B57;">{{ .context.Page.Title }}&nbsp</h3>
+    <h3 style="display: inline;">{{- T "group" $len -}}</h3>
+  </summary>
+    <ul>
+      {{ range .context.Pages.GroupBy "Title" }}
+      {{ $len := len .Pages }}
+      <details>
+        <summary>
+          <h3 style="display: inline; color: #2E8B57;">{{ .Key}}&nbsp</h3>
+          <h3 style="display: inline;">{{- T "article" $len -}}</h3>
+        </summary>
+        <br>
+        {{range .Pages}}
+          <ul>
+            <li>
+              {{if $collapseBySummary}}
+                <a href="{{ .RelPermalink }}">{{ safeHTML (substr .Summary 0 20)}}...</a>
+              {{else}}
+                <a href="{{ .RelPermalink }}">{{.Title}}...</a>
+              {{end}}
+            </li>
+          </ul>
+        {{ end }}
+        <br>
+      </details>
+      {{ end }}
+    </ul>
+</details>
+

--- a/layouts/tags/terms.html
+++ b/layouts/tags/terms.html
@@ -6,6 +6,8 @@
 
 {{ partial "header.html" . }}
 
+{{ $collapsibleTags := .Site.Params.collapsibleTags}}
+{{ $collapseBySummary := .Site.Params.collapseBySummary}}
 <div class="ui container">
   <article class="ui segment dream-tags-section">
     <h2 class="ui header">
@@ -20,17 +22,21 @@
     </h2>
 
     {{ range .Data.Terms.Alphabetical }}
-    <h3 class="ui header">
-      <a href="{{ .Page.RelPermalink }}">{{ .Page.Title }}</a>&nbsp;
-      {{- T "article" .Count -}}
-    </h3>
-    <ul>
-      {{ range .Pages }}
-      <li>
-        <a href="{{ .RelPermalink }}">{{ .Title }}</a>
-      </li>
-      {{ end }}
-    </ul>
+        {{ if $collapsibleTags }}
+            {{ partial  "collapsibleTags.html" (dict "context" . "collapseBySummary" $collapseBySummary)}}
+        {{ else }}
+            <h3 class="ui header">
+              <a href="{{ .Page.RelPermalink }}">{{ .Page.Title }}</a>&nbsp;
+              {{- T "article" .Count -}}
+            </h3>
+            <ul>
+              {{ range .Pages }}
+              <li>
+                <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+              </li>
+              {{ end }}
+            </ul>
+        {{ end }}
     {{ end }}
   </article>
 </div>


### PR DESCRIPTION
A change made based on the requirements from idolstation website where the tags need to be collapsible.

Added some logic in original terms.html and a new separated collapsibleTags.html page in partial folder.

Added "collapseBySummary" option so that user can decide whether they want to show .Content or .Summary.