### PR TITLE
How to add more identifiers to the header bar on the blog page?

### DIFF
--- a/layouts/categories/terms.html
+++ b/layouts/categories/terms.html
@@ -22,9 +22,8 @@
 
       {{ $data := .Data }}
       {{ range .Data.Terms.Alphabetical }}
-        {{ $termLink := printf "/%s/%s/" $data.Plural .Term | urlize }}
         <h2 class="ui medium header">
-          <a href="{{ $termLink }}">{{ .Term | humanize | title }}</a>&nbsp;
+          <a href="{{ .Page.RelPermalink }}">{{ .Page.Title }}</a>&nbsp;
           {{- T "article" .Count -}}
         </h2>
         <ul>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -40,11 +40,9 @@
 
   {{ if .Site.Taxonomies.tags }}
   <section class="ui attached center aligned segment dream-tags">
-    {{ range $name, $_ := .Site.Taxonomies.tags }}
-      {{ $link := printf "/tags/%s/" $name | urlize | relLangURL }}
-      {{ $title := $name | humanize | title }}
-      <a class="ui label" href="{{ $link }}" title="{{ $title }}">
-        {{ $title }}
+    {{ range .Site.Taxonomies.tags }}
+      <a class="ui label" href="{{ .Page.RelPermalink }}" title="{{ .Page.Title }}">
+        {{ .Page.Title }}
       </a>
     {{ end }}
   </section>

--- a/layouts/tags/terms.html
+++ b/layouts/tags/terms.html
@@ -22,9 +22,8 @@
 
       {{ $data := .Data }}
       {{ range .Data.Terms.Alphabetical }}
-        {{ $termLink := printf "/%s/%s/" $data.Plural .Term | urlize }}
         <h2 class="ui medium header">
-          <a href="{{ $termLink }}">{{ .Term | humanize | title }}</a>&nbsp;
+          <a href="{{ .Page.RelPermalink }}">{{ .Page.Title }}</a>&nbsp;
           {{- T "article" .Count -}}
         </h2>
         <ul>


### PR DESCRIPTION
I greatly appreciate and being thankful to you for creating this theme! I'm not a web dev but I want to know if there is a way I can add more identifiers on the header bar on the blog page? (Idk the specific name of it, but I meant the things on the top left corner of the webpage, cuz now there's only for, flipping, home, dark mode and search), I wish I can add more to it but till now I still can't find a way on adding identifiers, so is there a way it is possible to add these things with icons?