### PR TITLE
feat: support arbitrary taxonomies

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,7 +6,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ block "title" . }} {{- T "home" -}} {{ end }} | {{ .Site.Title }}</title>
+    <title>{{ block "title" . -}} {{ T "home" }} {{- end }} | {{ .Site.Title }}</title>
 
     {{ partial "head.html" . }}
 

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -1,5 +1,5 @@
 {{ define "title" }}
-{{- .Data.Term -}}
+{{- .Title -}}
 {{ end }}
 
 {{ define "main"}}
@@ -7,16 +7,16 @@
 <div class="flex flex-col md:flex-row gap-4 mt-8 lg:mt-12 px-4">
   <div class="md:basis-[200px] lg:basis-[300px] prose dark:prose-invert">
     <h1 class="text-2xl">
-      {{- .Data.Term -}}
+      {{- .Title -}}
     </h1>
     <p class="text-sm">
       {{- T "article" (len .Pages) -}}
     </p>
     <div class="flex flex-wrap gap-4 mt-6">
-      {{ $data := .Data }}
+      {{ $title := .Title }}
 
       {{ range (index site.Taxonomies .Data.Plural).Alphabetical }}
-      {{ if eq .Page.Title $data.Term }}
+      {{ if eq .Page.Title $title }}
       <span class="badge h-6 badge-primary">
         {{ .Page.Title }}
       </span>

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -14,18 +14,8 @@
     </p>
     <div class="flex flex-wrap gap-4 mt-6">
       {{ $data := .Data }}
-      {{ $singular := $data.Singular }}
-      {{ $pages := slice }}
 
-      {{ if eq $singular "category" }}
-      {{ $pages = site.Taxonomies.categories }}
-      {{ end }}
-
-      {{ if eq $singular "tag" }}
-      {{ $pages = site.Taxonomies.tags }}
-      {{ end }}
-
-      {{ range $pages.Alphabetical }}
+      {{ range (index site.Taxonomies .Data.Plural).Alphabetical }}
       {{ if eq .Page.Title $data.Term }}
       <span class="badge h-6 badge-primary">
         {{ .Page.Title }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,5 +1,7 @@
 {{ define "title" }}
-{{- T (print "all" (strings.FirstUpper .Data.Plural)) -}}
+{{ $title := (strings.FirstUpper .Data.Plural) }}
+{{ $translation := T (print "all" $title) }}
+{{ default $title $translation -}}
 {{ end }}
 
 {{ define "main"}}
@@ -7,14 +9,15 @@
 <div class="flex flex-col md:flex-row gap-4 mt-8 lg:mt-12 px-4">
   <div class="md:basis-[200px] lg:basis-[300px] prose dark:prose-invert">
     <h1 class="text-2xl">
-      {{- T (print "all" (strings.FirstUpper .Data.Plural)) -}}
+      {{- $title := T (print "all" (strings.FirstUpper .Data.Plural)) }}
+      {{- default (strings.FirstUpper .Data.Plural) $title -}}
     </h1>
     <p class="text-sm">
       {{- if eq (len .Data.Terms) 1 }}
-      {{- T .Data.Singular 1 }}
+      {{- default (print "1 " .Data.Singular) (T .Data.Singular 1) }}
       {{- else }}
-      {{- T .Data.Singular (len .Data.Terms) }}
-      {{- end }}
+      {{- default (print (len .Data.Terms) " " .Data.Plural) (T .Data.Singular (len .Data.Terms)) }}
+      {{- end -}}
     </p>
     <div class="flex flex-wrap gap-4 mt-6">
       {{ range .Data.Terms.Alphabetical }}
@@ -26,7 +29,7 @@
   </div>
   <div class="divider divider-vertical md:divider-horizontal"></div>
   <div class="flex-1 space-y-4">
-    {{ $paginator := .Paginate (where .Site.RegularPages "Type" "posts") }}
+    {{ $paginator := .Paginate (where site.RegularPages (print ".Params." .Data.Plural) "ne" nil) }}
     {{ range $paginator.Pages }}
     {{ .Render "term-summary" }}
     {{ end }}


### PR DESCRIPTION
Close #269

This PR updated the `terms.html` and `term.html` to support rendering arbitrary taxonomies. For example, you can custom a `series` taxonomy:

```toml
[taxonomies]
category = "categories"
tag = "tags"
series = "series"
```