### PR TITLE
fix: relative paths of resources

### DIFF
--- a/hugo.example.toml
+++ b/hugo.example.toml
@@ -14,12 +14,12 @@ theme = "hugo-theme-dream"
 lightTheme = "emerald"
 darkTheme = "forest"
 
-# backgroundImage = "/me/background.jpg"
+# backgroundImage = "me/background.jpg"
 # backgroundImageDark = ""
 
 author = "Dream"
 # description = ""
-# avatar = "/img/avatar.png"
+# avatar = "img/avatar.png"
 headerTitle = "Hugo Theme Dream"
 # motto = ""
 
@@ -38,7 +38,7 @@ headerTitle = "Hugo Theme Dream"
 
 siteStartYear = 2016
 
-# favicon = "/favicon.ico"
+# favicon = "favicon.ico"
 
 # Syntax highlighting
 # customSyntaxHighlighting = true

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,5 +1,5 @@
 {{ if isset site.Params "favicon" }}
-<link href="{{ site.Params.favicon }}" rel="shortcut icon" type="image/x-icon" />
+<link href="{{ site.Params.favicon | relURL }}" rel="shortcut icon" type="image/x-icon" />
 {{ end }}
 
 {{ if eq .Type "posts" }}
@@ -23,18 +23,18 @@
 <!-- Site Generator -->
 {{ hugo.Generator }}
 
-<link rel="stylesheet" href="{{ "/css/output.css" | relURL }}" />
+<link rel="stylesheet" href="{{ "css/output.css" | relURL }}" />
 
 <style>
 {{ if site.Params.backgroundImage }}
 #dream-global-bg {
-  background-image: url({{ site.Params.backgroundImage }});
+  background-image: url({{ site.Params.backgroundImage | relURL }});
 }
 {{ end }}
 
 {{ if site.Params.backgroundImageDark }}
 html.dark #dream-global-bg {
-  background-image: url({{ site.Params.backgroundImageDark }});
+  background-image: url({{ site.Params.backgroundImageDark | relURL }});
 }
 {{ end }}
 </style>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -26,5 +26,5 @@
 </script>
 <script src="https://cdn.jsdelivr.net/npm/imagesloaded@5.0.0/imagesloaded.pkgd.min.js" integrity="sha256-htrLFfZJ6v5udOG+3kNLINIKh2gvoKqwEhHYfTTMICc=" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/masonry-layout@4.2.2/dist/masonry.pkgd.min.js" integrity="sha256-Nn1q/fx0H7SNLZMQ5Hw5JLaTRZp0yILA/FRexe19VdI=" crossorigin="anonymous"></script>
-<script src="{{ "/js/grid.js" | relURL }}"></script>
-<script src="{{ "/js/main.js" | relURL }}"></script>
+<script src="{{ "js/grid.js" | relURL }}"></script>
+<script src="{{ "js/main.js" | relURL }}"></script>


### PR DESCRIPTION
From #294, some resources will fail to be accessed if someone uses a subdomain for site deployment.

Refer to https://gohugo.io/functions/urls/relurl/#input-does-not-begin-with-a-slash, all resources in templates should remove the `/` prefix.

This PR also applies the `relURL` pipeline to some unprocessed resources.