### PR TITLE
chore!: deprecate `hasTwitterEmbed` param

### DIFF
--- a/docs/pages/params-configurations.mdx
+++ b/docs/pages/params-configurations.mdx
@@ -52,7 +52,6 @@ stickyNav = true
 showTableOfContents = true
 showSummaryCoverInPost = true
 showPrevNextPost = true
-# hasTwitterEmbed = true
 
 [params.advanced]
 # customCSS = ["css/custom.css"]
@@ -235,12 +234,6 @@ Show summary cover image in the single post page.
 ### showPrevNextPost
 
 Show previous and next post links in the single post page.
-
-### hasTwitterEmbed
-
-If you have embedded twitter components generated from https://publish.twitter.com/, please set this param to `true` for better performance.
-
-After setting this, you can safely remove the async script in the generated code.
 
 ## Advanced
 

--- a/hugo.example.toml
+++ b/hugo.example.toml
@@ -53,7 +53,6 @@ siteStartYear = 2016
 # showTableOfContents = true
 # showSummaryCoverInPost = true
 # showPrevNextPost = true
-# hasTwitterEmbed = true
 
 # [params.navItems]
 

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,28 +1,6 @@
 <script>
   window.lightTheme = {{ site.Params.lightTheme }}
   window.darkTheme = {{ site.Params.darkTheme }}
-
-  window.hasTwitterEmbed = {{ site.Params.hasTwitterEmbed }}
-  if (window.hasTwitterEmbed) {
-    // https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/set-up-twitter-for-websites
-    window.twttr = (function (d, s, id) {
-      var js,
-        fjs = d.getElementsByTagName(s)[0],
-        t = window.twttr || {}
-      if (d.getElementById(id)) return t
-      js = d.createElement(s)
-      js.id = id
-      js.src = 'https://platform.twitter.com/widgets.js'
-      fjs.parentNode.insertBefore(js, fjs)
-
-      t._e = []
-      t.ready = function (f) {
-        t._e.push(f)
-      }
-
-      return t
-    })(document, 'script', 'twitter-wjs')
-  }
 </script>
 {{ if not site.Params.zenMode }}
 <script src="https://cdn.jsdelivr.net/npm/imagesloaded@5.0.0/imagesloaded.pkgd.min.js" integrity="sha256-htrLFfZJ6v5udOG+3kNLINIKh2gvoKqwEhHYfTTMICc=" crossorigin="anonymous"></script>

--- a/src/js/grid.js
+++ b/src/js/grid.js
@@ -5,10 +5,6 @@ function initGrid() {
     })
 
     imagesLoaded(grid, () => msnry.layout())
-
-    if (window.hasTwitterEmbed) {
-      window.twttr.ready((twttr) => twttr.events.bind('loaded', () => msnry.layout()))
-    }
   })
 }
 

--- a/static/js/grid.js
+++ b/static/js/grid.js
@@ -8,13 +8,6 @@ function initGrid() {
     imagesLoaded(grid, function () {
       return msnry.layout();
     });
-    if (window.hasTwitterEmbed) {
-      window.twttr.ready(function (twttr) {
-        return twttr.events.bind('loaded', function () {
-          return msnry.layout();
-        });
-      });
-    }
   });
 }
 initGrid();


### PR DESCRIPTION
The original purpose of the `hasTwitterEmbed` parameter was to optimize the rendering of twitter embedded cards in the summary card. But this would make the masonry layout incongruous. I recommend against using embedded cards from twitter/Instagram etc in the summary.