### PR TITLE
fix: usage of schema template

### DIFF
--- a/docs/pages/CHANGELOG.md
+++ b/docs/pages/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-None.
+### Fixed
+
+- Incorrect use of the `_internal/schema.html` template [#306](https://github.com/g1eny0ung/hugo-theme-dream/pull/306)
 
 ## [3.6.0] - 2024-08-24
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -43,7 +43,9 @@
       {{ .TableOfContents }}
     </div>
     {{ end }}
-    <article class="mx-auto prose dark:prose-invert" id="dream-single-post-main">
+    <article class="mx-auto prose dark:prose-invert" id="dream-single-post-main" itemscope itemtype="http://schema.org/Article">
+      {{ template "_internal/schema.html" . }}
+
       <header>
         <h1>{{ .Title }}</h1>
         <p class="text-sm">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -47,7 +47,7 @@
       {{ template "_internal/schema.html" . }}
 
       <header>
-        <h1>{{ .Title }}</h1>
+        <h1 itemprop="headline">{{ .Title }}</h1>
         <p class="text-sm">
           {{ if site.Params.Experimental.jsDate }}
             <span data-format="luxon">{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}</span>

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -9,15 +9,17 @@
   <span>@</span>
   {{ end }}
 
-  <span>
+  <span itemprop="author" itemscope itemtype="https://schema.org/Person">
   {{ if .Params.author }}
     {{ if and .Params.authorlink (eq .template "single") }}
-      <a href="{{ .Params.authorlink }}" target="_blank">{{ .Params.author }}</a>
+      <a itemprop="url" href="{{ .Params.authorlink }}" target="_blank">
+        <span itemprop="name">{{ .Params.author }}</span>
+      </a>
     {{ else }}
-      {{ .Params.author }}
+      <span itemprop="name">{{ .Params.author }}</span>
     {{ end }}
   {{ else }}
-    {{ site.Params.author }}
+    <span itemprop="name">{{ site.Params.author }}</span>
   {{ end }}
   </span>
 </div>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -28,7 +28,7 @@
 {{ else }}
 <!-- Site Author & Description -->
 <meta name="author" content="{{ site.Params.author }}" />
-<meta name="description" content="{{ site.Params.description }}" />
+<meta name="description" content="{{ site.Params.description | plainify }}" />
 {{ end }}
 
 <!-- Site Generator -->

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,6 +8,23 @@
 <!-- Page Author & Description -->
 <meta name="author" content="{{ if isset .Params "author" }}{{ .Params.author }}{{ else }}{{ site.Params.author }}{{ end }}" />
 <meta name="description" content="{{ .Summary | plainify }}" />
+
+<!-- Keywords -->
+{{- $keywords := slice }}
+{{- with .Keywords }}
+  {{- $keywords = . }}
+{{- else }}
+  {{- range .GetTerms "tags" }}
+    {{- $keywords = $keywords | append .Title }}
+  {{- else }}
+    {{- range $taxonomy, $_ := site.Taxonomies }}
+      {{- range $.GetTerms $taxonomy }}
+        {{- $keywords = $keywords | append .Title }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+<meta name="keywords" content="{{ delimit $keywords `,` }}">
 {{ else }}
 <!-- Site Author & Description -->
 <meta name="author" content="{{ site.Params.author }}" />

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,24 +4,24 @@
 
 <link rel="canonical" href="{{ .Permalink }}" />
 
-{{ template "_internal/schema.html" . }}
-
 {{ if eq .Type "posts" }}
-<!-- Page Author -->
+<!-- Page Author & Description -->
 <meta name="author" content="{{ if isset .Params "author" }}{{ .Params.author }}{{ else }}{{ site.Params.author }}{{ end }}" />
+<meta name="description" content="{{ .Summary | plainify }}" />
 {{ else }}
-<!-- Site Author -->
+<!-- Site Author & Description -->
 <meta name="author" content="{{ site.Params.author }}" />
+<meta name="description" content="{{ site.Params.description }}" />
 {{ end }}
+
+<!-- Site Generator -->
+{{ hugo.Generator }}
 
 <!-- Open Graph -->
 {{ template "_internal/opengraph.html" . }}
 
 <!-- Twitter Cards -->
 {{ template "_internal/twitter_cards.html" . }}
-
-<!-- Site Generator -->
-{{ hugo.Generator }}
 
 <link rel="stylesheet" href="{{ "css/output.css" | relURL }}" />
 


### PR DESCRIPTION
in #305, I placed the schema template in the head, but upon further research, I found that I was misusing it.

Here are some of the results of my research:

- https://stackoverflow.com/questions/46610201/schema-org-head-html-markup-can-i-just-use-the-meta-tags
- https://stackoverflow.com/questions/10279277/do-you-put-schema-microdata-meta-tags-in-the-html-body
- https://developers.google.com/search/docs/appearance/structured-data/article