### PR TITLE
feat: add `valineConfig` param

### DIFF
--- a/docs/pages/CHANGELOG.md
+++ b/docs/pages/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-None.
+### Added
+
+- Add `valineConfig` param to customize Valine comments
+
+### Deprecated
+
+- Deprecate `VALINE_LANGUAGE` param
 
 ## [3.7.0] - 2024-08-29
 

--- a/docs/pages/CHANGELOG.md
+++ b/docs/pages/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Add `valineConfig` param to customize Valine comments
+- Add `valineConfig` param to customize Valine comments [#309](https://github.com/g1eny0ung/hugo-theme-dream/pull/309)
 
 ### Deprecated
 
-- Deprecate `VALINE_LANGUAGE` param
+- Deprecate `VALINE_LANGUAGE` param [#309](https://github.com/g1eny0ung/hugo-theme-dream/pull/309)
 
 ## [3.7.0] - 2024-08-29
 

--- a/docs/pages/params-configurations.mdx
+++ b/docs/pages/params-configurations.mdx
@@ -33,7 +33,6 @@ utterancesRepo = "g1eny0ung/g1eny0ung.github.io"
 # valine = true
 # LEANCLOUD_APP_ID = ""
 # LEANCLOUD_APP_KEY = ""
-# VALINE_LANGUAGE = ""
 
 email = "g1enyy0ung@gmail.com"
 
@@ -52,6 +51,8 @@ stickyNav = true
 showTableOfContents = true
 showSummaryCoverInPost = true
 showPrevNextPost = true
+
+# [params.valineConfig]
 
 [params.advanced]
 # customCSS = ["css/custom.css"]
@@ -145,19 +146,26 @@ View https://utteranc.es for more details.
 ### valine
 
 Valine is a fast, simple & efficient Leancloud based no back end comment system.
+You can view https://valine.js.org/en/index.html for more details.
 
-To make it work, you still need to set first two parameters:
+To make it work, you still need to set these two parameters:
 
 ```toml
 [params]
 LEANCLOUD_APP_ID = ""
 LEANCLOUD_APP_KEY = ""
-VALINE_LANGUAGE = "" # optional
 ```
 
-Default language param is "zh-CN" , other supported languages are "zh-TW" , "en" , "ja" .
+You can also use `[params.valineConfig]` to customize Valine comments. For example:
 
-View https://valine.js.org/en/quickstart for more details.
+```toml
+[params.valineConfig]
+pageSize = 5
+```
+
+This will set the number of comments per page to 5.
+
+Refer to https://valine.js.org/en/configuration.html for the full list of configurations.
 
 ### siteStartYear
 

--- a/hugo.example.toml
+++ b/hugo.example.toml
@@ -34,7 +34,6 @@ headerTitle = "Hugo Theme Dream"
 # valine = true
 # LEANCLOUD_APP_ID = ""
 # LEANCLOUD_APP_KEY = ""
-# VALINE_LANGUAGE = ""
 
 # email = ""
 
@@ -55,6 +54,8 @@ siteStartYear = 2016
 # showPrevNextPost = true
 
 # [params.navItems]
+
+# [params.valineConfig]
 
 # [params.advanced]
 # customCSS = ["css/custom.css"]

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -145,7 +145,9 @@
         el: '#vcomments',
         appId: '{{ site.Params.LEANCLOUD_APP_ID }}',
         appKey: '{{ site.Params.LEANCLOUD_APP_KEY }}',
-        lang: '{{ site.Params.VALINE_LANGUAGE }}'
+        {{- range $k, $v := site.Params.valineConfig }}
+        {{ $k }}: {{ $v }},
+        {{- end }}
       })
     </script>
     {{ end }}


### PR DESCRIPTION
This PR adds the `valineConfig` param to customize Valine comments.

The old `VALINE_LANGUAGE` param is deprecated because now you can define it in `valineConfig`.