### PR TITLE
feat!: a new way to customize Valine

### DIFF
--- a/docs/pages/CHANGELOG.md
+++ b/docs/pages/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Add `valineConfig` param to customize Valine comments [#309](https://github.com/g1eny0ung/hugo-theme-dream/pull/309)
+- Valine comments can now be customized using a partial file [#311](https://github.com/g1eny0ung/hugo-theme-dream/pull/311)
 - Support [Waline](https://waline.js.org/en/) comments [#310](https://github.com/g1eny0ung/hugo-theme-dream/pull/310)
 
 ### Deprecated

--- a/docs/pages/params-configurations.mdx
+++ b/docs/pages/params-configurations.mdx
@@ -55,8 +55,6 @@ showTableOfContents = true
 showSummaryCoverInPost = true
 showPrevNextPost = true
 
-# [params.valineConfig]
-
 [params.advanced]
 # customCSS = ["css/custom.css"]
 # customJS = []
@@ -160,16 +158,14 @@ LEANCLOUD_APP_ID = ""
 LEANCLOUD_APP_KEY = ""
 ```
 
-You can also use `[params.valineConfig]` to customize Valine comments. For example:
+To customize Valine, you can create a partial file named `valine.html` in the `layouts/partials` folder.
+Here is an [example](https://github.com/g1eny0ung/blog/blob/master/layouts/partials/valine.html).
 
-```toml
-[params.valineConfig]
-pageSize = 5
-```
+<Callout type="info">
+You still need to set the `valine` parameter to `true` to enable Valine when using a custom partial file.
 
-This will set the number of comments per page to 5.
-
-Refer to https://valine.js.org/en/configuration.html for the full list of configurations.
+Other related parameters will be ingored.
+</Callout>
 
 ### waline
 
@@ -184,12 +180,14 @@ waline = true
 walineServer = "https://your-waline-server.com"
 ```
 
-If you want to customize Waline for a advanced usage,
+If you want to customize Waline,
 you can create a partial file named `waline.html` in the `layouts/partials` folder.
 Here is an [example](https://github.com/g1eny0ung/blog/blob/master/layouts/partials/waline.html).
 
 <Callout type="info">
 You still need to set the `waline` parameter to `true` to enable Waline when using a custom partial file.
+
+Other related parameters will be ingored.
 </Callout>
 
 ### siteStartYear

--- a/hugo.example.toml
+++ b/hugo.example.toml
@@ -58,8 +58,6 @@ siteStartYear = 2016
 
 # [params.navItems]
 
-# [params.valineConfig]
-
 # [params.advanced]
 # customCSS = ["css/custom.css"]
 # customJS = []

--- a/layouts/partials/commentSystems.html
+++ b/layouts/partials/commentSystems.html
@@ -21,27 +21,26 @@
 
 {{ if site.Params.valine }}
 <article>
+{{ if fileExists "layouts/partials/valine.html" }}
+  {{ partialCached "valine.html" . }}
+{{ else }}
   <div id="vcomments"></div>
   <script>
     new Valine({
       el: '#vcomments',
       appId: '{{ site.Params.LEANCLOUD_APP_ID }}',
-      appKey: '{{ site.Params.LEANCLOUD_APP_KEY }}',
-      {{- range $k, $v := site.Params.valineConfig }}
-      {{ $k }}: {{ $v }},
-      {{- end }}
+      appKey: '{{ site.Params.LEANCLOUD_APP_KEY }}'
     })
   </script>
+{{ end }}
 </article>
 {{ end }}
 
 {{ if site.Params.waline }}
+<article>
 {{ if fileExists "layouts/partials/waline.html" }}
-<article>
   {{ partialCached "waline.html" . }}
-</article>
 {{ else }}
-<article>
   <div id="waline"></div>
   <script type="module">
     import { init } from 'https://unpkg.com/@waline/client@v3/dist/waline.js';
@@ -52,6 +51,6 @@
       serverURL: {{ site.Params.walineServer }},
     });
   </script>
-</article>
 {{ end }}
+</article>
 {{ end }}


### PR DESCRIPTION
In #309, I added a `valineConfig` to customize Valine comments. However, this approach has a drawback because it cannot pass js functions as Valine configuration items.

So this PR also allows you to add a partial file for customizing the Valine like #310.