### PR TITLE
feat: group posts with any layout in archives page

### DIFF
--- a/decapCMS/config.yml
+++ b/decapCMS/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: git-gateway
-  branch: master
+  branch: main
 publish_mode: editorial_workflow
 media_folder: static/img
 public_folder: /img

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -53,7 +53,9 @@
             {{ .Date | time.Format "Monday, Jan 2, 2006" }}
           {{ end }}
 
+          {{ if ne .Params.noreadingtime true }}
           | <span>{{ .ReadingTime }}{{ T "minuteRead" .ReadingTime }}</span>
+          {{ end }}
 
           {{ if ne .Params.nolastmod true }}
           | <span>{{ T "updateAt" }}

--- a/layouts/section/posts.html
+++ b/layouts/section/posts.html
@@ -16,7 +16,8 @@
 
   <div class="max-w-[65ch] mx-auto mt-8 lg:mt-12">
     <ul class="timeline timeline-vertical">
-      {{ range .Pages.GroupByDate "2006" }}
+      {{ $groupByDate := default "2006" .Params.group_by_date }}
+      {{ range .Pages.GroupByDate $groupByDate }}
       <li class="[--timeline-col-start:64px]">
         <hr class="dark:bg-base-content" />
         <div class="timeline-start !justify-self-start">


### PR DESCRIPTION
With this change, it's possible to define how to group posts in "content/post/_index.md" with the params "group_by_date".

Options:
group_by_date: "2006" (by years. Actually default)
group_by_date: "2006-01" (by months)
group_by_date: "2006-01-01" (by days)