### PR TITLE
Tweak English translations for `minuteRead` and `updateAt`

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -42,10 +42,10 @@ other = "Social Links"
 
 [minuteRead]
 one = " minute read"
-other = " minutes read"
+other = " minute read"
 
 [updateAt]
-other = "Update at"
+other = "Updated at"
 
 [prevPage]
 other = "Previous page"


### PR DESCRIPTION
Improves the language in the context that these translations are used within

- should say a **10 minute read** as opposed to a **10 minutes read**

@g1eny0ung please could you review this small tweak