### PR TITLE
feat: open external links in a new window

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,1 @@
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank"{{ end }}>{{ .Text }}</a>

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,1 +1,7 @@
-<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank"{{ end }}>{{ .Text }}</a>
+{{- $u := urls.Parse .Destination -}}
+<a href="{{ .Destination | safeURL }}"
+  {{- with .Title }} title="{{ . }}"{{ end -}}
+  {{- if $u.IsAbs }} target="_blank"{{ end -}}
+>
+  {{- with .Text }}{{ . }}{{ end -}}
+</a>


### PR DESCRIPTION
感谢作者提供的 [Hugo Theme Dream](https://g1en.site/hugo-theme-dream)

在利用模板制作网站的过程中，遇到了<a>跳转问题
为了实现站外跳转，本PR 对<a>跳转问题做了修改
markdown存在默认情况下， 存在无法跳转新页面的缺陷 
添加一个render-link.html，实现 同域名时自页面跳转，不同域名时新页面跳转的功能

試作品：https://myfont.us.kg/