### PR TITLE
更新 Twikoo 版本 & 修复 Twikoo 头像偏移问题

### DIFF
--- a/layouts/partials/commentSystems.html
+++ b/layouts/partials/commentSystems.html
@@ -61,7 +61,7 @@
   {{ partialCached "twikoo.html" . }}
 {{ else }}
   <div id="tcomment"></div>
-  <script src="https://cdn.jsdelivr.net/npm/twikoo@1.6.41/dist/twikoo.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/twikoo@1.7.7/dist/twikoo.min.js"></script>
   <script>
     twikoo.init({
       envId: {{ site.Params.twikoo.envID }},

--- a/layouts/partials/commentSystems.html
+++ b/layouts/partials/commentSystems.html
@@ -61,6 +61,12 @@
   {{ partialCached "twikoo.html" . }}
 {{ else }}
   <div id="tcomment"></div>
+  <style>
+    .twikoo :where(img) {
+      margin-top: 0em;
+      margin-bottom: 0em;
+    }
+  </style>
   <script src="https://cdn.jsdelivr.net/npm/twikoo@1.7.7/dist/twikoo.min.js"></script>
   <script>
     twikoo.init({


### PR DESCRIPTION
在默认情况下，使用 Twikoo 评论系统会出现头像向下偏移问题

<img width="979" height="617" alt="image" src="https://github.com/user-attachments/assets/d5b132a7-cc6a-4ddb-a49b-b2c0c7d91f0a" />
  
搜索发现，在添加 Twikoo 评论系统的 Pr 中，就有提到过这个问题，也给出了原因和解决方法，但似乎没有合并进去

https://github.com/g1eny0ung/hugo-theme-dream/pull/359#issuecomment-2652771242
