### PR TITLE
fix: allow links in the summary

### DIFF
--- a/assets/css/output.css
+++ b/assets/css/output.css
@@ -1104,8 +1104,8 @@
       }
     }
   }
-  .z-1 {
-    z-index: 1;
+  .z-10 {
+    z-index: 10;
   }
   .z-30 {
     z-index: 30;
@@ -2231,6 +2231,18 @@
       }
     }
   }
+  .after\:absolute {
+    &::after {
+      content: var(--tw-content);
+      position: absolute;
+    }
+  }
+  .after\:inset-0 {
+    &::after {
+      content: var(--tw-content);
+      inset: 0;
+    }
+  }
   .hover\:avatar-online {
     &:hover {
       @media (hover: hover) {
@@ -2464,6 +2476,17 @@
       --tw-prose-pre-bg: var(--tw-prose-invert-pre-bg);
       --tw-prose-th-borders: var(--tw-prose-invert-th-borders);
       --tw-prose-td-borders: var(--tw-prose-invert-td-borders);
+    }
+  }
+  .\[\&_a\]\:font-medium {
+    & a {
+      --tw-font-weight: var(--font-weight-medium);
+      font-weight: var(--font-weight-medium);
+    }
+  }
+  .\[\&_a\]\:underline {
+    & a {
+      text-decoration-line: underline;
     }
   }
   .\[\&_ion-icon\]\:text-lg {
@@ -3166,6 +3189,11 @@ html {
   inherits: false;
   initial-value: 0 0 #0000;
 }
+@property --tw-content {
+  syntax: "*";
+  initial-value: "";
+  inherits: false;
+}
 @layer properties {
   @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color:rgb(from red r g b)))) {
     *, ::before, ::after, ::backdrop {
@@ -3186,6 +3214,7 @@ html {
       --tw-ring-offset-width: 0px;
       --tw-ring-offset-color: #fff;
       --tw-ring-offset-shadow: 0 0 #0000;
+      --tw-content: "";
     }
   }
 }

--- a/docs/content/CHANGELOG.md
+++ b/docs/content/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Remove the extra space at the end of markdown links
-- Allow links in the summary
+- Allow links in the summary [#409](https://github.com/g1eny0ung/hugo-theme-dream/pull/409)
 
 ## [3.15.0] - 2026-04-30
 

--- a/docs/content/CHANGELOG.md
+++ b/docs/content/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Remove the extra space at the end of markdown links
+- Allow links in the summary
 
 ## [3.15.0] - 2026-04-30
 

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -1,4 +1,4 @@
-<a class="card bg-base-100 hover:bg-base-content/10 shadow-xl cursor-pointer dark:border dark:border-base-content/30" href="{{ .RelPermalink }}">
+<div class="card bg-base-100 hover:bg-base-content/10 shadow-xl cursor-pointer dark:border dark:border-base-content/30">
   {{ if .Params.cover }}
   <figure>
     {{ with .Resources.Get .Params.cover }}
@@ -28,17 +28,21 @@
   {{ end }}
 
   <div class="card-body">
-    <h2 class="card-title">{{ .Title }}</h2>
+    <h2 class="card-title">
+      <a class="after:absolute after:inset-0" href="{{ .RelPermalink }}">{{ .Title }}</a>
+    </h2>
 
     <p class="date text-base-content/60">
-    {{ if site.Params.Experimental.jsDate }}
-      <span data-format="luxon">{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}</span>
-    {{ else }}
-      {{ .Date | time.Format "Monday, Jan 2, 2006" }}
-    {{ end }}
+      {{ if site.Params.Experimental.jsDate }}
+        <span data-format="luxon">{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}</span>
+      {{ else }}
+        {{ .Date | time.Format "Monday, Jan 2, 2006" }}
+      {{ end }}
     </p>
 
-    {{ or .Description (.Summary | emojify | safeHTML) }}
+    <p class="[&_a]:font-medium [&_a]:underline z-10">
+      {{- or .Description (.Summary | replaceRE "^<p>" "" | replaceRE "</p>$" "" | emojify | safeHTML) -}}
+    </p>
 
     {{ $hasAuthor := or .Params.author site.Params.author }}
     <div class="card-actions justify-between items-center mt-4">
@@ -52,4 +56,4 @@
       </div>
     </div>
   </div>
-</a>
+</div>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -41,7 +41,7 @@
       <div tabindex="0" role="button" class="btn btn-ghost btn-square" aria-label="Select an option">
         <ion-icon name="menu" class="text-2xl"></ion-icon>
       </div>
-      <ul tabindex="0" class="dropdown-content menu w-36 bg-base-100 rounded-box z-1 shadow-md">
+      <ul tabindex="0" class="dropdown-content menu w-36 bg-base-100 rounded-box z-10 shadow-md">
         {{ partial "navMobileMenu.html" (dict "navItems" $navItems) }}
       </ul>
     </div>
@@ -68,7 +68,7 @@
         <div tabindex="0" role="button" class="group inline-flex items-center p-2 rounded-full cursor-pointer hover:bg-primary" aria-label="Select an option">
           <ion-icon class="group-hover:text-primary-content text-xl" name="menu"></ion-icon>
         </div>
-        <ul tabindex="0" class="dropdown-content menu w-36 bg-base-100 rounded-box z-1 shadow-xl">
+        <ul tabindex="0" class="dropdown-content menu w-36 bg-base-100 rounded-box z-10 shadow-xl">
           {{ range $collapseNavItems }}
           {{ partial "renderMobileNavItem.html" . }}
           {{ end }}


### PR DESCRIPTION
Fix #408

This PR updated the summary card from an`<a>` to a `<div>`, and then put the post link into the title and maintained the original effect by updating the CSS.